### PR TITLE
Fix undefined variable error

### DIFF
--- a/source/HighlyConfigurableWheel.scad
+++ b/source/HighlyConfigurableWheel.scad
@@ -458,7 +458,7 @@ module wheel() {
 							circleSpokes( d, wheelWidth, spokeWidth, proportion, numberOfSpokes );
 						} else if ( spokeStyle == "spiral" ) {
 							spiralSpokes( d, wheelWidth, numberOfSpokes,
-								spokeWidth, curvature, reverse, spiralSpoke);
+								spokeWidth, curvature, reverse);
 						}
 					}
 	


### PR DESCRIPTION
Preview gives error 

`
"WARNING: Too many unnamed arguments supplied in file HighlyConfigurableWheel_spiralajo.scad, line 461"
`

Issue traced to variable "spiralSpoke" in calling function spiralSpokes. 